### PR TITLE
Fix config override

### DIFF
--- a/comet-java-client/pom.xml
+++ b/comet-java-client/pom.xml
@@ -41,6 +41,16 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.12.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.32</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.32</version>
+		</dependency>
 
 		<!-- tests -->
 		<dependency>

--- a/comet-java-client/src/main/java/ml/comet/experiment/builder/OnlineExperimentBuilder.java
+++ b/comet-java-client/src/main/java/ml/comet/experiment/builder/OnlineExperimentBuilder.java
@@ -28,6 +28,20 @@ public interface OnlineExperimentBuilder {
     OnlineExperimentBuilder withApiKey(String apiKey);
 
     /**
+     * Set the max auth retry attempts.
+     * @param maxAuthRetries number of times to try auth calls on experiment creation
+     * @return
+     */
+    OnlineExperimentBuilder withMaxAuthRetries(int maxAuthRetries);
+
+    /**
+     * Set the URL of your comet installation.
+     * @param urlOverride full url of comet installation. default is https://www.comet.ml
+     * @return
+     */
+    OnlineExperimentBuilder  withUrlOverride(String urlOverride);
+
+    /**
      * Name the experiment
      * @param experimentName name to be applied to the experiment
      * @return

--- a/comet-java-client/src/main/java/ml/comet/experiment/constants/Constants.java
+++ b/comet-java-client/src/main/java/ml/comet/experiment/constants/Constants.java
@@ -30,7 +30,6 @@ public class Constants {
     public static final String GET_TAGS = READ_API_URL + "/experiment/tags";
     public static final String GET_ASSET_INFO = READ_API_URL + "/experiment/asset/list";
 
-    public static final String DEFAULTS_CONF = "defaults.conf";
     public static final String COMET_API_KEY = "comet.apiKey";
     public static final String COMET_PROJECT = "comet.project";
     public static final String COMET_WORKSPACE = "comet.workspace";

--- a/comet-java-client/src/main/java/ml/comet/experiment/exception/CometGeneralException.java
+++ b/comet-java-client/src/main/java/ml/comet/experiment/exception/CometGeneralException.java
@@ -1,0 +1,23 @@
+package ml.comet.experiment.exception;
+
+public class CometGeneralException extends RuntimeException{
+    /**
+     * Constructs a new runtime exception with {@code null} as its
+     * detail message.  The cause is not initialized, and may subsequently be
+     * initialized by a call to {@link #initCause}.
+     */
+    public CometGeneralException() {
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     */
+    public CometGeneralException(String message) {
+        super(message);
+    }
+}

--- a/comet-java-client/src/test/java/ml/comet/experiment/ApiExperimentTest.java
+++ b/comet-java-client/src/test/java/ml/comet/experiment/ApiExperimentTest.java
@@ -1,9 +1,43 @@
 package ml.comet.experiment;
 
+import ml.comet.experiment.exception.CometGeneralException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
+import java.net.URL;
+
+import static org.junit.Assert.fail;
+
 public class ApiExperimentTest extends BaseApiTest {
+
+
+    @Test(expected = CometGeneralException.class)
+    public void testApiExperimentInitializedWithInvalidValues() {
+        OnlineExperimentImpl.builder()
+                .withMaxAuthRetries(1)
+                .withUrlOverride("https://invalid.invalid")
+                .withApiKey("invalid")
+                .withWorkspace("invalid")
+                .withProjectName("invalid")
+                .build();
+    }
+
+    @Test
+    public void testApiExperimentInitializedWithConfigOverride() {
+        try {
+            URL url = Thread.currentThread().getContextClassLoader().getResource("comet-override.conf");
+            File file = new File(url.getPath());
+            OnlineExperimentImpl.builder()
+                    .withConfig(file)
+                    .build();
+        } catch (IllegalArgumentException ex) {
+            Assert.assertEquals("Apikey is not specified!", ex.getMessage());
+            return;
+        }
+
+        fail("expected to read comet override config file");
+    }
 
     @Test
     public void testApiExperimentInitialized() {

--- a/comet-java-client/src/test/resources/comet-override.conf
+++ b/comet-java-client/src/test/resources/comet-override.conf
@@ -1,0 +1,4 @@
+comet {
+    url = "https://www.comet.ml"
+    apiKey = "invalid"
+}


### PR DESCRIPTION
This PR will allow users to set config values as:
* Environment variables 
* config file (by specifying file path)
* default typesafe config from classpath (`defaults.conf`)

In addition moved validation to `build()` function (was on init) 
updated tests