### PR TITLE
[NA]: Bump version to 1.1.4

### DIFF
--- a/comet-examples/pom.xml
+++ b/comet-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>comet-java-sdk</artifactId>
         <groupId>ml.comet</groupId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/comet-java-client/pom.xml
+++ b/comet-java-client/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>ml.comet</groupId>
 		<artifactId>comet-java-sdk</artifactId>
-		<version>1.1.3-SNAPSHOT</version>
+		<version>1.1.4-SNAPSHOT</version>
 	</parent>
 
 	<dependencyManagement>

--- a/comet-java-client/src/test/java/ml/comet/experiment/OnlineExperimentTest.java
+++ b/comet-java-client/src/test/java/ml/comet/experiment/OnlineExperimentTest.java
@@ -251,7 +251,7 @@ public class OnlineExperimentTest extends BaseApiTest {
         awaitForCondition(() -> {
             ExperimentMetadataRest data = existingExperiment.getMetadata();
             return data.getStartTimeMillis() == now && data.getEndTimeMillis() == now;
-        }, "Experiment start/stop time updated", 180);
+        }, "Experiment start/stop time updated", 240);
 
         ExperimentMetadataRest updatedMetadata = existingExperiment.getMetadata();
         assertNotEquals(startTimeMillis, updatedMetadata.getStartTimeMillis());

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>ml.comet</groupId>
   <artifactId>comet-java-sdk</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.3-SNAPSHOT</version>
+  <version>1.1.4-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>https://www.comet.ml Java client lib</description>


### PR DESCRIPTION
# Change Log
### comet-java-client
- Reading Java Comet SDK version from the resource file filtered by Maven.
- Implemented printing Java Comet SDK version at the experiment start.
- Fixed potential resource leak in the `StdOutLogger` implementation.
- Implemented `StdOutLogger.flush()` to facilitate system stream flushing before closing logger.
- Fixed `OnlineExperimentImpl.stopInterceptStdout()` to use `StdOutLogger.flush()` before closing logger.
- Renamed `OnlineExperimentImpl.statusPing()` to `OnlineExperimentImpl.sendHeartbeat()` for better readability.
- Refactored Comet configuration framework to support massive number of configuration options, default configuration values from bundled resource properties, and for better readability.
- Refactored experiment builders by extracting common methods.
- Extracted string constants with asset types into `Enum` for better type safety.
- Extracted string constants with query parameter names into `Enum` for better type safety.

### comet-examples
- Changed backend of the logger from `log4j` to `ch.qos.logback`.
- Upgraded `deeplearning4j` to the latest version to address security issues with older versions.
- Fixed MNIST experiment example to use latest version of the `deeplearning4j`.