### PR TITLE
[CM-2110] Implement LoggedArtifact.getAsset(String assetLogicalPath)

### DIFF
--- a/comet-examples/src/main/java/ml/comet/examples/ArtifactExample.java
+++ b/comet-examples/src/main/java/ml/comet/examples/ArtifactExample.java
@@ -85,7 +85,7 @@ public class ArtifactExample implements BaseExample {
 
         // add local assets
         //
-        artifact.addAsset(getResourceFile(CHART_IMAGE_FILE), "amazing chart.png", false, SOME_METADATA);
+        artifact.addAsset(getResourceFile(CHART_IMAGE_FILE), AMAZING_CHART_NAME, false, SOME_METADATA);
         artifact.addAsset(getResourceFile(MODEL_FILE), false);
         byte[] someData = "some data".getBytes(StandardCharsets.UTF_8);
         String someDataName = "someDataName";
@@ -184,6 +184,12 @@ public class ArtifactExample implements BaseExample {
         System.out.printf("\nArtifact update completed, new artifact version created: %s\n\n",
                 loggedArtifact.getFullName());
 
+        // get artifact asset by logical path
+        //
+        System.out.printf("Finding asset '%s' of the artifact: %s\n", AMAZING_CHART_NAME, loggedArtifact.getFullName());
+        asset = loggedArtifact.getAsset(AMAZING_CHART_NAME);
+        System.out.printf("Successfully found asset '%s' of the artifact: %s\n\n",
+                asset, loggedArtifact.getFullName());
 
         System.out.println("===== Experiment completed ====");
     }

--- a/comet-examples/src/main/java/ml/comet/examples/BaseExample.java
+++ b/comet-examples/src/main/java/ml/comet/examples/BaseExample.java
@@ -16,6 +16,7 @@ import static ml.comet.examples.Utils.readResourceToString;
  */
 interface BaseExample {
     String CHART_IMAGE_FILE = "chart.png";
+    String AMAZING_CHART_NAME = "amazing chart.png";
     String MODEL_FILE = "model.hd5";
     String HTML_REPORT_FILE = "report.html";
     String GRAPH_JSON_FILE = "graph.json";

--- a/comet-java-client/src/main/java/ml/comet/experiment/artifact/ArtifactAssetNotFoundException.java
+++ b/comet-java-client/src/main/java/ml/comet/experiment/artifact/ArtifactAssetNotFoundException.java
@@ -1,0 +1,18 @@
+package ml.comet.experiment.artifact;
+
+/**
+ * Exception to be raised when specific asset of the Comet artifact was not found.
+ */
+public class ArtifactAssetNotFoundException extends ArtifactException {
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     */
+    public ArtifactAssetNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/comet-java-client/src/main/java/ml/comet/experiment/artifact/LoggedArtifact.java
+++ b/comet-java-client/src/main/java/ml/comet/experiment/artifact/LoggedArtifact.java
@@ -114,14 +114,24 @@ public interface LoggedArtifact {
     Collection<LoggedArtifactAsset> getRemoteAssets() throws ArtifactException;
 
     /**
-     * Allows reading list of assets associated with this artifact from Comet backend.
+     * Allows reading list of assets associated with this artifact from the Comet backend.
      *
      * <p>This method is the remote method invocation and will contact the Comet backend.
      *
      * @return the list of {@link LoggedArtifactAsset} associated with this artifact.
-     * @throws ArtifactException if failed to read assets from Comet.
+     * @throws ArtifactException if failed to read assets from the Comet.
      */
     Collection<LoggedArtifactAsset> getAssets() throws ArtifactException;
+
+    /**
+     * Allows getting asset keyed by provided {@code logicalPath} from the Comet backend.
+     *
+     * @param assetLogicalPath the logical path of the asset.
+     * @return the {@link LoggedArtifactAsset} instance associated with given logical path.
+     * @throws ArtifactAssetNotFoundException if failed to find asset with given logical path.
+     * @throws ArtifactException              if operation failed.
+     */
+    LoggedArtifactAsset getAsset(String assetLogicalPath) throws ArtifactAssetNotFoundException, ArtifactException;
 
     /**
      * Download the current Artifact Version assets to a given directory.

--- a/comet-java-client/src/main/java/ml/comet/experiment/impl/LoggedArtifactImpl.java
+++ b/comet-java-client/src/main/java/ml/comet/experiment/impl/LoggedArtifactImpl.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
 import ml.comet.experiment.artifact.ArtifactAsset;
+import ml.comet.experiment.artifact.ArtifactAssetNotFoundException;
 import ml.comet.experiment.artifact.ArtifactDownloadException;
 import ml.comet.experiment.artifact.ArtifactException;
 import ml.comet.experiment.artifact.AssetOverwriteStrategy;
@@ -29,6 +30,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -37,6 +39,7 @@ import static java.nio.file.StandardOpenOption.READ;
 import static ml.comet.experiment.impl.resources.LogMessages.ARTIFACT_ASSETS_DOWNLOAD_COMPLETED;
 import static ml.comet.experiment.impl.resources.LogMessages.ARTIFACT_HAS_NO_ASSETS_TO_DOWNLOAD;
 import static ml.comet.experiment.impl.resources.LogMessages.FAILED_TO_DOWNLOAD_ARTIFACT_ASSETS;
+import static ml.comet.experiment.impl.resources.LogMessages.FAILED_TO_FIND_ASSET_IN_ARTIFACT;
 import static ml.comet.experiment.impl.resources.LogMessages.START_DOWNLOAD_ARTIFACT_ASSETS;
 import static ml.comet.experiment.impl.resources.LogMessages.getString;
 
@@ -130,6 +133,19 @@ public final class LoggedArtifactImpl extends BaseArtifactImpl implements Logged
     @Override
     public Collection<LoggedArtifactAsset> getAssets() throws ArtifactException {
         return this.baseExperiment.readArtifactAssets(this);
+    }
+
+    @Override
+    public LoggedArtifactAsset getAsset(String assetLogicalPath) throws ArtifactException {
+        Collection<LoggedArtifactAsset> assets = this.baseExperiment.readArtifactAssets(this);
+        for (LoggedArtifactAsset asset : assets) {
+            if (Objects.equals(assetLogicalPath, asset.getLogicalPath())) {
+                return asset;
+            }
+        }
+
+        throw new ArtifactAssetNotFoundException(getString(FAILED_TO_FIND_ASSET_IN_ARTIFACT,
+                assetLogicalPath, this.getFullName()));
     }
 
     @Override

--- a/comet-java-client/src/main/java/ml/comet/experiment/impl/resources/LogMessages.java
+++ b/comet-java-client/src/main/java/ml/comet/experiment/impl/resources/LogMessages.java
@@ -69,6 +69,7 @@ public class LogMessages {
     public static final String FAILED_TO_PARSE_REMOTE_ASSET_LINK = "FAILED_TO_PARSE_REMOTE_ASSET_LINK";
     public static final String FAILED_TO_SET_ARTIFACT_VERSION_LEQ_THAN_CURRENT =
             "FAILED_TO_SET_ARTIFACT_VERSION_LEQ_THAN_CURRENT";
+    public static final String FAILED_TO_FIND_ASSET_IN_ARTIFACT = "FAILED_TO_FIND_ASSET_IN_ARTIFACT";
 
 
     /**

--- a/comet-java-client/src/main/resources/messages.properties
+++ b/comet-java-client/src/main/resources/messages.properties
@@ -54,3 +54,4 @@ FAILED_TO_DELETE_TEMPORARY_ASSET_FILE=Failed to delete temporary file '%s' of th
 REMOTE_ASSET_CANNOT_BE_DOWNLOADED=Failed to download/read remote asset %s. Please use asset's URI to download/read it directly.
 FAILED_TO_PARSE_REMOTE_ASSET_LINK=Failed to parse remote asset link %s.
 FAILED_TO_SET_ARTIFACT_VERSION_LEQ_THAN_CURRENT=Failed to set new version of the artifact %s, it is lower than or equal of current %s
+FAILED_TO_FIND_ASSET_IN_ARTIFACT=No asset found with logical path '%s' in the artifact '%s'.


### PR DESCRIPTION
### comet-java-client
- Implemented `LoggedArtifact.getAsset(String assetLogicalPath)` method

### comet-examples
- Added example of `LoggedArtifact.getAsset(String assetLogicalPath)` method's usage