### PR TITLE
[CM-2342]: Fixed parent POM to move Sonatype plugins dependencies into releases profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,19 +61,6 @@
     </snapshotRepository>
   </distributionManagement>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-gpg-plugin</artifactId>
-      <version>3.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.plugins</groupId>
-      <artifactId>nexus-staging-maven-plugin</artifactId>
-      <version>1.6.8</version>
-    </dependency>
-  </dependencies>
-
   <profiles>
 
     <!-- GPG Signature on release -->
@@ -90,6 +77,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -109,7 +97,8 @@
         </plugins>
       </build>
     </profile>
- 
+
+    <!-- Release to maven central -->
     <profile>
       <id>releases</id>
       <build>
@@ -117,6 +106,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
             <executions>
               <execution>
                 <id>default-deploy</id>
@@ -181,7 +171,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
In order to check dependency tree the following command should be executed in the root of the project: 
`mvn dependency:tree`

After fix, the dependency tree of the `comet-java-client` project looks like following:
```text
[INFO] ml.comet:comet-java-client:jar:1.1.7-SNAPSHOT
[INFO] +- org.asynchttpclient:async-http-client:jar:2.12.3:compile
[INFO] |  +- org.asynchttpclient:async-http-client-netty-utils:jar:2.12.3:compile
[INFO] |  |  \- io.netty:netty-buffer:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.1.60.Final:compile
[INFO] |  |  +- io.netty:netty-common:jar:4.1.60.Final:compile
[INFO] |  |  +- io.netty:netty-transport:jar:4.1.60.Final:compile
[INFO] |  |  \- io.netty:netty-codec:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-handler:jar:4.1.60.Final:compile
[INFO] |  |  \- io.netty:netty-resolver:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-codec-socks:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-handler-proxy:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.60.Final:compile
[INFO] |  |  \- io.netty:netty-transport-native-unix-common:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |  +- com.typesafe.netty:netty-reactive-streams:jar:2.0.4:compile
[INFO] |  \- com.sun.activation:jakarta.activation:jar:1.2.2:compile
[INFO] +- io.reactivex.rxjava3:rxjava:jar:3.1.3:compile
[INFO] +- org.projectlombok:lombok:jar:1.18.22:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] +- commons-io:commons-io:jar:2.11.0:compile
[INFO] +- com.typesafe:config:jar:1.4.1:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.1:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.1:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.13.1:compile
[INFO] +- com.vdurmont:semver4j:jar:3.1.0:compile
[INFO] +- org.awaitility:awaitility:jar:4.1.1:compile
[INFO] |  \- org.hamcrest:hamcrest:jar:2.1:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.33:compile
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.33:compile
[INFO] +- org.junit.jupiter:junit-jupiter:jar:5.8.1:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.8.1:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.8.1:test
[INFO] |  |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-params:jar:5.8.1:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.8.1:test
[INFO] |     \- org.junit.platform:junit-platform-engine:jar:1.8.1:test
[INFO] +- org.mockito:mockito-inline:jar:4.2.0:test
[INFO] |  \- org.mockito:mockito-core:jar:4.2.0:test
[INFO] |     +- net.bytebuddy:byte-buddy:jar:1.12.4:test
[INFO] |     +- net.bytebuddy:byte-buddy-agent:jar:1.12.4:test
[INFO] |     \- org.objenesis:objenesis:jar:3.2:test
[INFO] +- com.github.tomakehurst:wiremock-jre8:jar:2.32.0:test
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:9.4.44.v20210927:test
[INFO] |  |  +- javax.servlet:javax.servlet-api:jar:3.1.0:test
[INFO] |  |  +- org.eclipse.jetty:jetty-http:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:9.4.44.v20210927:test
[INFO] |  |  +- org.eclipse.jetty:jetty-security:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.44.v20210927:test
[INFO] |  |  +- org.eclipse.jetty:jetty-continuation:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-webapp:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-xml:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-proxy:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-client:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty.http2:http2-server:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty.http2:http2-common:jar:9.4.44.v20210927:test
[INFO] |  |     \- org.eclipse.jetty.http2:http2-hpack:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-openjdk8-server:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-alpn-client:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-openjdk8-client:jar:9.4.44.v20210927:test
[INFO] |  +- com.google.guava:guava:jar:31.0.1-jre:test
[INFO] |  |  +- com.google.guava:failureaccess:jar:1.0.1:test
[INFO] |  |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:test
[INFO] |  |  +- com.google.code.findbugs:jsr305:jar:3.0.2:test
[INFO] |  |  +- org.checkerframework:checker-qual:jar:3.12.0:test
[INFO] |  |  +- com.google.errorprone:error_prone_annotations:jar:2.7.1:test
[INFO] |  |  \- com.google.j2objc:j2objc-annotations:jar:1.3:test
[INFO] |  +- org.apache.httpcomponents.client5:httpclient5:jar:5.1:test
[INFO] |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.1.1:test
[INFO] |  |  +- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.1.1:test
[INFO] |  |  \- commons-codec:commons-codec:jar:1.15:compile
[INFO] |  +- org.xmlunit:xmlunit-core:jar:2.8.3:test
[INFO] |  |  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:test
[INFO] |  |     \- jakarta.activation:jakarta.activation-api:jar:1.2.2:test
[INFO] |  +- org.xmlunit:xmlunit-legacy:jar:2.8.3:test
[INFO] |  +- org.xmlunit:xmlunit-placeholders:jar:2.8.3:test
[INFO] |  +- net.javacrumbs.json-unit:json-unit-core:jar:2.28.0:test
[INFO] |  |  \- org.hamcrest:hamcrest-core:jar:2.2:test
[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.6.0:test
[INFO] |  |  \- net.minidev:json-smart:jar:2.4.7:test
[INFO] |  |     \- net.minidev:accessors-smart:jar:2.4.7:test
[INFO] |  +- org.ow2.asm:asm:jar:9.2:compile
[INFO] |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
[INFO] |  +- com.github.jknack:handlebars:jar:4.3.0:test
[INFO] |  +- com.github.jknack:handlebars-helpers:jar:4.3.0:test
[INFO] |  \- commons-fileupload:commons-fileupload:jar:1.4:test
[INFO] \- org.apache.maven.plugins:maven-surefire-plugin:jar:3.0.0-M5:compile
[INFO]    \- org.apache.maven.surefire:maven-surefire-common:jar:3.0.0-M5:compile
[INFO]       +- org.apache.maven.surefire:surefire-api:jar:3.0.0-M5:compile
[INFO]       |  \- org.apache.maven.surefire:surefire-logger-api:jar:3.0.0-M5:compile
[INFO]       +- org.apache.maven.surefire:surefire-extensions-api:jar:3.0.0-M5:compile
[INFO]       +- org.apache.maven.surefire:surefire-booter:jar:3.0.0-M5:compile
[INFO]       |  \- org.apache.maven.surefire:surefire-extensions-spi:jar:3.0.0-M5:compile
[INFO]       +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:compile
[INFO]       +- org.apache.maven.shared:maven-artifact-transfer:jar:0.11.0:compile
[INFO]       |  \- org.apache.maven.shared:maven-common-artifact-filters:jar:3.0.1:compile
[INFO]       |     +- org.apache.maven:maven-model:jar:3.0:compile
[INFO]       |     +- org.apache.maven:maven-plugin-api:jar:3.0:compile
[INFO]       |     +- org.sonatype.sisu:sisu-inject-plexus:jar:1.4.2:compile
[INFO]       |     |  +- org.codehaus.plexus:plexus-classworlds:jar:2.2.3:compile
[INFO]       |     |  \- org.sonatype.sisu:sisu-inject-bean:jar:1.4.2:compile
[INFO]       |     |     \- org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7:compile
[INFO]       |     \- org.apache.maven.shared:maven-shared-utils:jar:3.1.0:compile
[INFO]       +- org.codehaus.plexus:plexus-java:jar:1.0.5:compile
[INFO]       |  \- com.thoughtworks.qdox:qdox:jar:2.0-M9:compile
[INFO]       \- org.apache.maven.surefire:surefire-shared-utils:jar:3.0.0-M4:compile
```

From above can be seen no dependency on `org.sonatype.plugins:nexus-staging-maven-plugin` plugin.

If we are running the dependency tree scanner from master it will include dependency on `org.sonatype.plugins:nexus-staging-maven-plugin` and has output as following:
```text
[INFO] ml.comet:comet-java-client:jar:1.1.7-SNAPSHOT
[INFO] +- org.asynchttpclient:async-http-client:jar:2.12.3:compile
[INFO] |  +- org.asynchttpclient:async-http-client-netty-utils:jar:2.12.3:compile
[INFO] |  |  \- io.netty:netty-buffer:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.1.60.Final:compile
[INFO] |  |  +- io.netty:netty-common:jar:4.1.60.Final:compile
[INFO] |  |  +- io.netty:netty-transport:jar:4.1.60.Final:compile
[INFO] |  |  \- io.netty:netty-codec:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-handler:jar:4.1.60.Final:compile
[INFO] |  |  \- io.netty:netty-resolver:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-codec-socks:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-handler-proxy:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.60.Final:compile
[INFO] |  |  \- io.netty:netty-transport-native-unix-common:jar:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |  +- com.typesafe.netty:netty-reactive-streams:jar:2.0.4:compile
[INFO] |  \- com.sun.activation:jakarta.activation:jar:1.2.2:compile
[INFO] +- io.reactivex.rxjava3:rxjava:jar:3.1.3:compile
[INFO] +- org.projectlombok:lombok:jar:1.18.22:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] +- commons-io:commons-io:jar:2.11.0:compile
[INFO] +- com.typesafe:config:jar:1.4.1:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.1:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.1:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.13.1:compile
[INFO] +- com.vdurmont:semver4j:jar:3.1.0:compile
[INFO] +- org.awaitility:awaitility:jar:4.1.1:compile
[INFO] |  \- org.hamcrest:hamcrest:jar:2.1:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.33:compile
[INFO] +- org.slf4j:slf4j-simple:jar:1.7.33:compile
[INFO] +- org.junit.jupiter:junit-jupiter:jar:5.8.1:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.8.1:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  +- org.junit.platform:junit-platform-commons:jar:1.8.1:test
[INFO] |  |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-params:jar:5.8.1:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-engine:jar:5.8.1:test
[INFO] |     \- org.junit.platform:junit-platform-engine:jar:1.8.1:test
[INFO] +- org.mockito:mockito-inline:jar:4.2.0:test
[INFO] |  \- org.mockito:mockito-core:jar:4.2.0:test
[INFO] |     +- net.bytebuddy:byte-buddy:jar:1.12.4:test
[INFO] |     +- net.bytebuddy:byte-buddy-agent:jar:1.12.4:test
[INFO] |     \- org.objenesis:objenesis:jar:3.2:test
[INFO] +- com.github.tomakehurst:wiremock-jre8:jar:2.32.0:test
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:9.4.44.v20210927:test
[INFO] |  |  +- javax.servlet:javax.servlet-api:jar:3.1.0:test
[INFO] |  |  +- org.eclipse.jetty:jetty-http:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:9.4.44.v20210927:test
[INFO] |  |  +- org.eclipse.jetty:jetty-security:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.44.v20210927:test
[INFO] |  |  +- org.eclipse.jetty:jetty-continuation:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-webapp:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-xml:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-proxy:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-client:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty.http2:http2-server:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty.http2:http2-common:jar:9.4.44.v20210927:test
[INFO] |  |     \- org.eclipse.jetty.http2:http2-hpack:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-openjdk8-server:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.44.v20210927:test
[INFO] |  |  \- org.eclipse.jetty:jetty-alpn-client:jar:9.4.44.v20210927:test
[INFO] |  +- org.eclipse.jetty:jetty-alpn-openjdk8-client:jar:9.4.44.v20210927:test
[INFO] |  +- com.google.guava:guava:jar:31.0.1-jre:compile
[INFO] |  |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  |  +- org.checkerframework:checker-qual:jar:3.12.0:compile
[INFO] |  |  +- com.google.errorprone:error_prone_annotations:jar:2.7.1:compile
[INFO] |  |  \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] |  +- org.apache.httpcomponents.client5:httpclient5:jar:5.1:test
[INFO] |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.1.1:test
[INFO] |  |  +- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.1.1:test
[INFO] |  |  \- commons-codec:commons-codec:jar:1.15:compile
[INFO] |  +- org.xmlunit:xmlunit-core:jar:2.8.3:test
[INFO] |  |  \- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:test
[INFO] |  |     \- jakarta.activation:jakarta.activation-api:jar:1.2.2:test
[INFO] |  +- org.xmlunit:xmlunit-legacy:jar:2.8.3:test
[INFO] |  +- org.xmlunit:xmlunit-placeholders:jar:2.8.3:test
[INFO] |  +- net.javacrumbs.json-unit:json-unit-core:jar:2.28.0:test
[INFO] |  |  \- org.hamcrest:hamcrest-core:jar:2.2:test
[INFO] |  +- com.jayway.jsonpath:json-path:jar:2.6.0:test
[INFO] |  |  \- net.minidev:json-smart:jar:2.4.7:test
[INFO] |  |     \- net.minidev:accessors-smart:jar:2.4.7:test
[INFO] |  +- org.ow2.asm:asm:jar:9.2:compile
[INFO] |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
[INFO] |  +- com.github.jknack:handlebars:jar:4.3.0:test
[INFO] |  +- com.github.jknack:handlebars-helpers:jar:4.3.0:test
[INFO] |  \- commons-fileupload:commons-fileupload:jar:1.4:test
[INFO] +- org.apache.maven.plugins:maven-surefire-plugin:jar:3.0.0-M5:compile
[INFO] |  \- org.apache.maven.surefire:maven-surefire-common:jar:3.0.0-M5:compile
[INFO] |     +- org.apache.maven.surefire:surefire-api:jar:3.0.0-M5:compile
[INFO] |     |  \- org.apache.maven.surefire:surefire-logger-api:jar:3.0.0-M5:compile
[INFO] |     +- org.apache.maven.surefire:surefire-extensions-api:jar:3.0.0-M5:compile
[INFO] |     +- org.apache.maven.surefire:surefire-booter:jar:3.0.0-M5:compile
[INFO] |     |  \- org.apache.maven.surefire:surefire-extensions-spi:jar:3.0.0-M5:compile
[INFO] |     +- org.apache.maven:maven-toolchain:jar:3.0-alpha-2:compile
[INFO] |     +- org.codehaus.plexus:plexus-java:jar:1.0.5:compile
[INFO] |     |  \- com.thoughtworks.qdox:qdox:jar:2.0-M9:compile
[INFO] |     \- org.apache.maven.surefire:surefire-shared-utils:jar:3.0.0-M4:compile
[INFO] +- org.apache.maven.plugins:maven-gpg-plugin:jar:3.0.1:compile
[INFO] |  +- org.apache.maven:maven-plugin-api:jar:3.0:compile
[INFO] |  |  \- org.sonatype.sisu:sisu-inject-plexus:jar:1.4.2:compile
[INFO] |  |     \- org.sonatype.sisu:sisu-inject-bean:jar:1.4.2:compile
[INFO] |  |        \- org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7:compile
[INFO] |  +- org.apache.maven:maven-core:jar:3.0:compile
[INFO] |  |  +- org.apache.maven:maven-settings-builder:jar:3.0:compile
[INFO] |  |  +- org.apache.maven:maven-repository-metadata:jar:3.0:compile
[INFO] |  |  +- org.apache.maven:maven-aether-provider:jar:3.0:runtime
[INFO] |  |  +- org.sonatype.aether:aether-impl:jar:1.7:compile
[INFO] |  |  |  \- org.sonatype.aether:aether-spi:jar:1.7:compile
[INFO] |  |  +- org.sonatype.aether:aether-util:jar:1.7:compile
[INFO] |  |  +- org.codehaus.plexus:plexus-classworlds:jar:2.2.3:compile
[INFO] |  |  \- org.codehaus.plexus:plexus-component-annotations:jar:1.5.5:compile
[INFO] |  +- org.apache.maven:maven-artifact:jar:3.0:compile
[INFO] |  +- org.apache.maven:maven-model:jar:3.0:compile
[INFO] |  +- org.apache.maven:maven-model-builder:jar:3.0:compile
[INFO] |  +- org.apache.maven:maven-settings:jar:3.0:compile
[INFO] |  +- org.apache.maven.shared:maven-artifact-transfer:jar:0.12.0:compile
[INFO] |  |  \- org.apache.maven.shared:maven-common-artifact-filters:jar:3.0.1:compile
[INFO] |  |     \- org.apache.maven.shared:maven-shared-utils:jar:3.1.0:compile
[INFO] |  +- org.codehaus.plexus:plexus-utils:jar:3.3.0:compile
[INFO] |  \- org.sonatype.plexus:plexus-sec-dispatcher:jar:1.4:compile
[INFO] |     \- org.sonatype.plexus:plexus-cipher:jar:1.4:compile
[INFO] \- org.sonatype.plugins:nexus-staging-maven-plugin:jar:1.6.8:compile
[INFO]    +- org.sonatype.nexus.maven:nexus-common:jar:1.6.8:compile
[INFO]    +- org.sonatype.nexus:nexus-client-core:jar:2.14.3-02:compile
[INFO]    |  +- org.sonatype.nexus.plugins:nexus-restlet1x-model:jar:2.14.3-02:compile
[INFO]    |  +- com.intellij:annotations:jar:12.0:compile
[INFO]    |  +- com.thoughtworks.xstream:xstream:jar:1.4.7:compile
[INFO]    |  |  +- xmlpull:xmlpull:jar:1.1.3.1:compile
[INFO]    |  |  \- xpp3:xpp3_min:jar:1.1.4c:compile
[INFO]    |  +- joda-time:joda-time:jar:2.2:compile
[INFO]    |  +- commons-lang:commons-lang:jar:2.6:compile
[INFO]    |  +- commons-beanutils:commons-beanutils-core:jar:1.8.3-SONATYPE:compile
[INFO]    |  |  \- commons-collections:commons-collections:jar:3.2.1:compile
[INFO]    |  +- org.sonatype.sisu.siesta:siesta-client:jar:1.7:compile
[INFO]    |  |  +- org.sonatype.sisu.siesta:siesta-common:jar:1.7:compile
[INFO]    |  |  |  +- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO]    |  |  |  +- com.sun.jersey:jersey-core:jar:1.17.1:compile
[INFO]    |  |  |  \- javax.validation:validation-api:jar:1.1.0.Final:compile
[INFO]    |  |  +- com.sun.jersey:jersey-client:jar:1.17.1:compile
[INFO]    |  |  \- com.sun.jersey.contribs:jersey-apache-client4:jar:1.17.1:compile
[INFO]    |  +- org.sonatype.sisu.siesta:siesta-jackson:jar:1.7:compile
[INFO]    |  |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.3.1:compile
[INFO]    |  |  |  \- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.3.1:compile
[INFO]    |  |  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.3.1:compile
[INFO]    |  +- org.apache.httpcomponents:httpclient:jar:4.3.6:compile
[INFO]    |  +- org.apache.httpcomponents:httpcore:jar:4.3.3:compile
[INFO]    |  +- org.slf4j:jcl-over-slf4j:jar:1.7.6:compile
[INFO]    |  \- javax.inject:javax.inject:jar:1:compile
[INFO]    +- org.sonatype.spice.zapper:spice-zapper:jar:1.3:compile
[INFO]    |  \- org.fusesource.hawtbuf:hawtbuf-proto:jar:1.9:compile
[INFO]    |     \- org.fusesource.hawtbuf:hawtbuf:jar:1.9:compile
[INFO]    +- org.codehaus.plexus:plexus-interpolation:jar:1.15:compile
[INFO]    +- org.sonatype.aether:aether-api:jar:1.13.1:compile
[INFO]    +- ch.qos.logback:logback-core:jar:1.1.2:runtime
[INFO]    \- ch.qos.logback:logback-classic:jar:1.1.2:runtime
```